### PR TITLE
Add Flutter Firebase project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+build/
+.dart_tool/
+.packages
+flutter_app/build/
+flutter_app/.dart_tool/

--- a/flutter_app/README.md
+++ b/flutter_app/README.md
@@ -1,0 +1,21 @@
+# DeepSpaceGhost Flutter App
+
+This directory contains a Flutter implementation of the DeepSpaceGhost chatbot, leveraging Firebase for backend services.
+
+## Getting Started
+
+1. Ensure [Flutter](https://flutter.dev/docs/get-started/install) and [FlutterFire CLI](https://firebase.flutter.dev/docs/cli) are installed.
+2. Configure Firebase for your project:
+   ```bash
+   flutterfire configure
+   ```
+3. Run the app:
+   ```bash
+   flutter run
+   ```
+
+## Security
+
+- Input is sanitized to mitigate injection attacks and enforce message length limits.
+- Replace the placeholder Firebase configuration in `lib/firebase_options.dart` using `flutterfire configure` and keep real credentials out of source control.
+- Configure Firebase Authentication and Firestore/Realtime Database security rules following NIST CSF, CISA, and PCI DSS guidance.

--- a/flutter_app/lib/firebase_options.dart
+++ b/flutter_app/lib/firebase_options.dart
@@ -1,0 +1,22 @@
+import 'package:firebase_core/firebase_core.dart';
+import 'package:flutter/foundation.dart';
+
+// Placeholder Firebase configuration.
+// Replace these values using `flutterfire configure`.
+// Avoid committing real credentials to version control.
+
+class DefaultFirebaseOptions {
+  static FirebaseOptions get currentPlatform {
+    if (kIsWeb) {
+      return const FirebaseOptions(
+        apiKey: 'YOUR_WEB_API_KEY',
+        authDomain: 'YOUR_PROJECT.firebaseapp.com',
+        projectId: 'YOUR_PROJECT',
+        storageBucket: 'YOUR_PROJECT.appspot.com',
+        messagingSenderId: 'SENDER_ID',
+        appId: 'APP_ID',
+      );
+    }
+    throw UnsupportedError('DefaultFirebaseOptions are not set for this platform.');
+  }
+}

--- a/flutter_app/lib/main.dart
+++ b/flutter_app/lib/main.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/material.dart';
+import 'package:firebase_core/firebase_core.dart';
+import 'firebase_options.dart';
+import 'security_utils.dart';
+
+void main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  await Firebase.initializeApp(
+    options: DefaultFirebaseOptions.currentPlatform,
+  );
+  runApp(const MyApp());
+}
+
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'DeepSpaceGhost',
+      theme: ThemeData(
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
+        useMaterial3: true,
+      ),
+      home: const MyHomePage(),
+    );
+  }
+}
+
+class MyHomePage extends StatefulWidget {
+  const MyHomePage({super.key});
+
+  @override
+  State<MyHomePage> createState() => _MyHomePageState();
+}
+
+class _MyHomePageState extends State<MyHomePage> {
+  final TextEditingController _controller = TextEditingController();
+  final List<String> _messages = [];
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('DeepSpaceGhost Chat'),
+      ),
+      body: Column(
+        children: [
+          Expanded(
+            child: ListView.builder(
+              itemCount: _messages.length,
+              itemBuilder: (context, index) => ListTile(
+                title: Text(_messages[index]),
+              ),
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.all(8.0),
+            child: Row(
+              children: [
+                Expanded(
+                  child: TextField(
+                    controller: _controller,
+                    decoration: const InputDecoration(
+                      hintText: 'Enter message',
+                    ),
+                  ),
+                ),
+                IconButton(
+                  icon: const Icon(Icons.send),
+                  onPressed: () {
+                    final sanitized = sanitizeMessage(_controller.text);
+                    if (sanitized.isEmpty) return;
+                    setState(() {
+                      _messages.add(sanitized);
+                      _controller.clear();
+                    });
+                  },
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/flutter_app/lib/security_utils.dart
+++ b/flutter_app/lib/security_utils.dart
@@ -1,0 +1,13 @@
+import 'dart:math';
+
+/// Basic sanitization utilities for user-provided input.
+///
+/// Removes characters that could be used for HTML/JS injection and
+/// enforces a maximum length to reduce the risk of buffer overflows or
+/// resource exhaustion.
+String sanitizeMessage(String input) {
+  final withoutAngles = input.replaceAll(RegExp(r'[<>]'), '');
+  final trimmed = withoutAngles.trim();
+  const maxLength = 500;
+  return trimmed.substring(0, min(trimmed.length, maxLength));
+}

--- a/flutter_app/pubspec.yaml
+++ b/flutter_app/pubspec.yaml
@@ -1,0 +1,21 @@
+name: deepspaceghost_flutter
+description: Flutter and Firebase version of DeepSpaceGhost chatbot.
+
+publish_to: 'none'
+
+environment:
+  sdk: ">=3.0.0 <4.0.0"
+
+dependencies:
+  flutter:
+    sdk: flutter
+  firebase_core: ^2.24.2
+  firebase_auth: ^4.15.3
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  flutter_lints: ^3.0.1
+
+flutter:
+  uses-material-design: true


### PR DESCRIPTION
## Summary
- add Flutter project scaffold with Firebase initialization and sample chat UI
- document setup steps and basic security considerations
- include input sanitization to mitigate injection attacks

## Testing
- `dart format flutter_app/lib/main.dart flutter_app/lib/security_utils.dart flutter_app/lib/firebase_options.dart flutter_app/README.md flutter_app/pubspec.yaml` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8a7f9ef9c832ba3886222dde7a613